### PR TITLE
bugfix: request paths need 'rest' and capital V

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ class ServerlessMagento implements ServerlessPlugin {
 
         const serviceName = this.service.service;
 
-        await this.axiosInstance.put(`/v1/service/registrations`, {
+        await this.axiosInstance.put(`/rest/V1/service/registrations`, {
             app_name: serviceName,
             display_name: displayName,
             description: description || this.getServiceDescription(),
@@ -130,7 +130,7 @@ class ServerlessMagento implements ServerlessPlugin {
      */
     private async deregisterService() {
         await this.axiosInstance.delete(
-            `/v1/service/registrations/${this.service.service}`,
+            `/rest/V1/service/registrations/${this.service.service}`,
         );
 
         this.log.success(


### PR DESCRIPTION
The documentation expects a magento base url ending with the domain, so the path requests must include `/rest/` to match Adobe Commerce API routes.

Additionally, AC appears to have an issue with `/v1/` instead of `/V1/` in the path.