### PR TITLE
Feature/micro 287 configurable error behaviour on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Microservices registered with the [magento2-microservice-config](https://bitbuck
 
 ## Admin Interface
 
-The admin interface is provided as a link to an externally hosed web application which is rendered in the Magento admin interface as an `iframe`. Authorisation context will be injected into the iframe when loaded.
+The admin interface is provided as a link to an externally hosted web application which is rendered in the Magento admin interface as an `iframe`. Authorisation context will be injected into the iframe when loaded.
 
 ## Deployment
 
@@ -32,11 +32,12 @@ custom:
 
 ### Variables
 
-| Variable              | Usage                                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------------ |
-| magentoUrl            | The base URL - including scheme - of the Magento instance.                                             |
-| magentoApiToken       | The api token for registering with Magento instance.                                                   |
-| displayName           | The name of the application/service.                                                                   |
-| description           | Short description about the application/service. If not provided, `resources/Description` will be used |
-| permission            | Array of Magento permission. Webapp does not need this                                                 |
-| domainOutputKeyPrefix | The prefix of webapp domain output key. The default value is `landingDomain`.                          |
+| Variable              | Type    | Usage                                                                                                           |
+| --------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| magentoUrl            | string  | The base URL - including scheme - of the Magento instance.                                                      |
+| magentoApiToken       | string  | The api token for registering with Magento instance.                                                            |
+| displayName           | string  | The name of the application/service.                                                                            |
+| description           | string  | Short description about the application/service. If not provided, `resources/Description` will be used          |
+| permission            | string  | Array of Magento permission. Webapp does not need this.                                                         |
+| domainOutputKeyPrefix | string  | The prefix of webapp domain output key. The default value is `landingDomain`.                                   |
+| errorOnFailure        | boolean | Whether the plugin should throw an error when a call to the Magento instance fails. The default value is `true` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/serverless-magento",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "A Serverless framework plugin for handling registration with the aligent/magento2-microservice-config module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ interface ServiceRegistration {
     description?: string;
     permissions?: string[];
     domainOutputKeyPrefix: string;
+    errorOnFailure?: boolean;
 }
 
 type ServerlessResources = Service['resources'] & {
@@ -76,6 +77,7 @@ class ServerlessMagento implements ServerlessPlugin {
                             items: { type: 'string' },
                         },
                         domainOutputKeyPrefix: { type: 'string' },
+                        errorOnFailure: { type: 'boolean' },
                     },
                     required: ['magentoUrl', 'magentoApiToken', 'displayName'],
                 },
@@ -91,6 +93,7 @@ class ServerlessMagento implements ServerlessPlugin {
 
     private async initialize() {
         this.serviceRegistration = {
+            errorOnFailure: true, // Default to throw an error when failing to register/deregister
             ...this.service.custom.serviceRegistration,
             domainOutputKeyPrefix:
                 this.service.custom.serviceRegistration.domainOutputKeyPrefix ||
@@ -155,7 +158,11 @@ class ServerlessMagento implements ServerlessPlugin {
                 )}`;
             }
 
-            throw new this.serverless.classes.Error(errorMessage);
+            if (this.serviceRegistration.errorOnFailure) {
+                throw new this.serverless.classes.Error(errorMessage);
+            } else {
+                this.log.warning(errorMessage);
+            }
         }
     }
 
@@ -186,7 +193,11 @@ class ServerlessMagento implements ServerlessPlugin {
                 )}`;
             }
 
-            throw new this.serverless.classes.Error(errorMessage);
+            if (this.serviceRegistration.errorOnFailure) {
+                throw new this.serverless.classes.Error(errorMessage);
+            } else {
+                this.log.warning(errorMessage);
+            }
         }
     }
 


### PR DESCRIPTION
If the backend is not deployed, registration calls made by this plugin will fail and the error thrown as a result blocks deployment entirely.

This PR adds an optional configuration flag to avoid throwing an error. Default behaviour is the same as before.